### PR TITLE
update lite_engine_op_test to pass unit test

### DIFF
--- a/paddle/fluid/operators/lite/lite_engine_op_test.cc
+++ b/paddle/fluid/operators/lite/lite_engine_op_test.cc
@@ -83,9 +83,9 @@ TEST(LiteEngineOp, engine_op) {
   platform::CPUDeviceContext ctx(place);
 #endif
   // Prepare variables.
-  CreateTensor(&scope, "x", std::vector<int64_t>({2, 4}));
-  CreateTensor(&scope, "y", std::vector<int64_t>({2, 4}));
-  CreateTensor(&scope, "out", std::vector<int64_t>({2, 4}));
+  CreateTensor(&scope, "x", std::vector<int64_t>({2, 4}), false);
+  CreateTensor(&scope, "y", std::vector<int64_t>({2, 4}), false);
+  CreateTensor(&scope, "out", std::vector<int64_t>({2, 4}), false);
 
   ASSERT_EQ(block_->ops_size(), 4);
 

--- a/paddle/fluid/operators/lite/ut_helper.h
+++ b/paddle/fluid/operators/lite/ut_helper.h
@@ -88,16 +88,21 @@ void RandomizeTensor(framework::LoDTensor* tensor,
 }
 
 void CreateTensor(framework::Scope* scope, const std::string& name,
-                  const std::vector<int64_t>& shape) {
+                  const std::vector<int64_t>& shape, bool in_cuda = true) {
   auto* var = scope->Var(name);
   auto* tensor = var->GetMutable<framework::LoDTensor>();
   auto dims = framework::make_ddim(shape);
   tensor->Resize(dims);
+  platform::Place place;
+  if (in_cuda) {
 #ifdef PADDLE_WITH_CUDA
-  platform::CUDAPlace place;
+    place = platform::CUDAPlace(0);
 #else
-  platform::CPUPlace place;
+    LOG(FATAL) << "You must define PADDLE_WITH_CUDA for using CUDAPlace.";
 #endif
+  } else {
+    place = platform::CPUPlace();
+  }
   RandomizeTensor(tensor, place);
 }
 


### PR DESCRIPTION
修复lite_engine_op_test。

因为该单测只run lite_engine op，该op block内部存在Lite子图，lite子图接收cpu tensor，而输入的是cuda tensor 因此挂掉